### PR TITLE
Fix script path

### DIFF
--- a/Gantt/Gantt/Pages/_Layout.cshtml
+++ b/Gantt/Gantt/Pages/_Layout.cshtml
@@ -28,6 +28,6 @@
     </div>
 
     <script src="_framework/blazor.server.js"></script>
-    <script src="~/js\gantt.js"></script>
+    <script src="~/js/gantt.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- update path to gantt script in layout page

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f01b9c6f08329b5d2f5262c2d44a0