### PR TITLE
Add column-based snapping for tasks

### DIFF
--- a/Gantt/Gantt/Models/TaskItem.cs
+++ b/Gantt/Gantt/Models/TaskItem.cs
@@ -5,8 +5,12 @@ namespace Gantt.Models
     public class TaskItem
     {
         public string Name { get; set; } = "";
-        public int StartPx { get; set; }
-        public int WidthPx { get; set; }
+        public int ColumnStart { get; set; }
+        public int ColumnSpan { get; set; }
         public ElementReference Ref;
+
+        public int StartPx(int columnWidth) => ColumnStart * columnWidth;
+
+        public int WidthPx(int columnWidth) => ColumnSpan * columnWidth;
     }
 }

--- a/Gantt/Gantt/Pages/Gantt/Chart.razor
+++ b/Gantt/Gantt/Pages/Gantt/Chart.razor
@@ -1,23 +1,26 @@
 ﻿@using global::Gantt.Models
 @inject IJSRuntime JS
 
-<div class="gantt-container">
+<div class="gantt-container" style="--column-width:@($"{ColumnWidth}px")">
     @foreach (var row in TaskRows)
     {
         <div class="gantt-row">
             @foreach (var task in row.Tasks)
             {
-               <Gantt.Pages.Gantt.GanttComponents.TaskComponent Task="task"/>
+               <Gantt.Pages.Gantt.GanttComponents.TaskComponent Task="task" ColumnWidth="ColumnWidth" />
             }
         </div>
     }
 </div>
 
 @code {
+    private const int ColumnWidth = 50;
+
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (firstRender)
         {
+            await JS.InvokeVoidAsync("setColumnWidth", ColumnWidth);
             await JS.InvokeVoidAsync("setupGanttDrag");
         }
     }
@@ -28,22 +31,22 @@
         {
             Tasks = new List<TaskItem>
             {
-                new() { Name = "Task A", StartPx = 50, WidthPx = 100 },
-                new() { Name = "Task B", StartPx = 200, WidthPx = 150 }
+                new() { Name = "Task A", ColumnStart = 1, ColumnSpan = 2 },
+                new() { Name = "Task B", ColumnStart = 4, ColumnSpan = 3 }
             }
         },
         new TaskRow
         {
             Tasks = new List<TaskItem>
             {
-                new() { Name = "Task C", StartPx = 30, WidthPx = 80 }
+                new() { Name = "Task C", ColumnStart = 0, ColumnSpan = 2 }
             }
         },
         new TaskRow
         {
             Tasks = new List<TaskItem>
             {
-                new() { Name = "Task D", StartPx = 30, WidthPx = 80 }
+                new() { Name = "Task D", ColumnStart = 0, ColumnSpan = 2 }
             }
         }
     };

--- a/Gantt/Gantt/Pages/Gantt/GanttComponents/TaskComponent.razor
+++ b/Gantt/Gantt/Pages/Gantt/GanttComponents/TaskComponent.razor
@@ -1,6 +1,6 @@
-﻿<div class="gantt-task"
+<div class="gantt-task"
      @ref="Task.Ref"
-     style="left:@(Task.StartPx)px; width:@(Task.WidthPx)px"
+     style="left:@(Task.StartPx(ColumnWidth))px; width:@(Task.WidthPx(ColumnWidth))px"
      @onmousedown="e => StartDrag(Task, e)">
     @Task.Name
 </div>

--- a/Gantt/Gantt/Pages/Gantt/GanttComponents/TaskComponent.razor
+++ b/Gantt/Gantt/Pages/Gantt/GanttComponents/TaskComponent.razor
@@ -1,6 +1,5 @@
 <div class="gantt-task"
      @ref="Task.Ref"
-     style="left:@(Task.StartPx(ColumnWidth))px; width:@(Task.WidthPx(ColumnWidth))px"
-     @onmousedown="e => StartDrag(Task, e)">
+     style="left:@(Task.StartPx(ColumnWidth))px; width:@(Task.WidthPx(ColumnWidth))px">
     @Task.Name
 </div>

--- a/Gantt/Gantt/Pages/Gantt/GanttComponents/TaskComponent.razor.cs
+++ b/Gantt/Gantt/Pages/Gantt/GanttComponents/TaskComponent.razor.cs
@@ -10,6 +10,8 @@ namespace Gantt.Pages.Gantt.GanttComponents
     {
         [Parameter]
         public TaskItem Task { get; set; }
+        [Parameter]
+        public int ColumnWidth { get; set; }
         [Inject]
         public IJSRuntime JS { get; set; }
 

--- a/Gantt/Gantt/wwwroot/css/gantt.css
+++ b/Gantt/Gantt/wwwroot/css/gantt.css
@@ -5,6 +5,8 @@
     padding: 10px;
     width: 100%;
     overflow-x: scroll;
+    background-image: linear-gradient(to right, #eee 1px, transparent 1px);
+    background-size: var(--column-width) 100%;
 }
 
 .gantt-row {

--- a/Gantt/Gantt/wwwroot/js/gantt.js
+++ b/Gantt/Gantt/wwwroot/js/gantt.js
@@ -21,17 +21,23 @@ window.setupGanttDrag = () => {
     document.addEventListener('mouseup', () => {
         console.log("mouseup!");
         if (currentTask) {
-            currentTask._startPx = parseInt(currentTask.style.left);
+            const px = parseInt(currentTask.style.left);
+            const column = Math.round(px / columnWidth);
+            if (currentTask._helper) {
+                currentTask._helper.invokeMethodAsync('OnDragEnd', column);
+            }
+            currentTask._startPx = px;
             currentTask = null;
         }
     });
 };
 
-window.enableTaskDrag = (element) => {
+window.enableTaskDrag = (element, dotnetHelper) => {
     element.addEventListener('mousedown', e => {
         console.log("mousedown!");
         currentTask = element;
         startX = e.clientX;
         element._startPx = parseInt(element.style.left);
+        element._helper = dotnetHelper;
     });
 };

--- a/Gantt/Gantt/wwwroot/js/gantt.js
+++ b/Gantt/Gantt/wwwroot/js/gantt.js
@@ -1,13 +1,20 @@
-﻿let currentTask = null;
+let currentTask = null;
 let startX = 0;
+let columnWidth = 50;
+
+window.setColumnWidth = (w) => {
+    columnWidth = w;
+};
+
 console.log("🔥 gantt.js LOADED 🔥");
 window.setupGanttDrag = () => {
     document.addEventListener('mousemove', e => {
         if (currentTask) {
             const dx = e.clientX - startX;
             const newLeft = currentTask._startPx + dx;
-            currentTask.style.left = `${newLeft}px`;
-            console.log(`🟢 przesuwam: ${newLeft}px`);
+            const snapped = Math.round(newLeft / columnWidth) * columnWidth;
+            currentTask.style.left = `${snapped}px`;
+            console.log(`🟢 przesuwam: ${snapped}px`);
         }
     });
 


### PR DESCRIPTION
## Summary
- introduce ColumnStart and ColumnSpan to TaskItem
- style Gantt container with column grid background
- snap dragged tasks to column width in JS
- supply column width from Chart and pass to TaskComponent

## Testing
- `dotnet build -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f0445a78883298d45f7a4a47c1f65